### PR TITLE
Add remote bitbucket

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -36,6 +36,10 @@
   <remote name="black-bit"
           fetch="https://bitbucket.org/NL-BlackDragon" />
 
+  <!-- Bitbucket -->
+  <remote name="bitbucket"
+          fetch="https://bitbucket.org/" />
+          
   <!-- Linaro -->
   <remote  name="linaro"
            fetch="git://android.git.linaro.org"


### PR DESCRIPTION
Add remote bitbucket for access to more and regularly updated Sabermod Toolchains from xanaxdroid, which can be added to device dependencies file.
